### PR TITLE
Work on content pane embedding.

### DIFF
--- a/src/main/java/com/example/protrack/applicationpages/EmbeddedViewExample.java
+++ b/src/main/java/com/example/protrack/applicationpages/EmbeddedViewExample.java
@@ -1,0 +1,4 @@
+package com.example.protrack.applicationpages;
+
+public class EmbeddedViewExample {
+}

--- a/src/main/java/com/example/protrack/applicationpages/HomePageController.java
+++ b/src/main/java/com/example/protrack/applicationpages/HomePageController.java
@@ -1,4 +1,28 @@
 package com.example.protrack.applicationpages;
 
+import com.example.protrack.Main;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.control.Button;
+
+import java.io.IOException;
+
 public class HomePageController {
+    @FXML
+    private AnchorPane mainContentPane;
+
+    @FXML
+    private Button loadContentPaneButton;
+
+    @FXML protected void onLoadContentPaneButtonClick () {
+        FXMLLoader fxmlLoader = new FXMLLoader(Main.class.getResource("embedded-view-example.fxml"));
+        try {
+            AnchorPane mainContent = (AnchorPane) fxmlLoader.load();
+            mainContentPane.getChildren().clear();
+            mainContentPane.getChildren().add(mainContent);
+        } catch (IOException e) {
+            System.out.println("Failed to load content pane!");
+        }
+    }
 }

--- a/src/main/resources/com/example/protrack/embedded-view-example.fxml
+++ b/src/main/resources/com/example/protrack/embedded-view-example.fxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="com.example.protrack.applicationpages.EmbeddedViewExample"
+            prefHeight="400.0" prefWidth="600.0">
+    <Label text="This is an embedded content pane."/>
+</AnchorPane>

--- a/src/main/resources/com/example/protrack/home-view.fxml
+++ b/src/main/resources/com/example/protrack/home-view.fxml
@@ -3,6 +3,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.AnchorPane?>
 
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.TextField?>
@@ -14,4 +15,6 @@
         <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
     </padding>
     <Label text="this is the main page"/>
+    <Button text="Load content pane" fx:id="loadContentPaneButton" onAction="#onLoadContentPaneButtonClick"/>
+    <AnchorPane fx:id="mainContentPane"/>
 </VBox>


### PR DESCRIPTION
This is an example implementation of a content pane that, when a button is clicked, loads the pane's content dynamically via another FXML file.

Placed intentionally inside the Home Page, since that's where it's likely to be later on, based on images of the medium fidelity prototype.